### PR TITLE
Implement createAnswer mutation, temp changes, and routing

### DIFF
--- a/backend/src/typesDefs.js
+++ b/backend/src/typesDefs.js
@@ -1,5 +1,5 @@
-
-const typeDefs = [`
+const typeDefs = [
+  `
 
     scalar Date
 
@@ -55,7 +55,7 @@ const typeDefs = [`
       createQuestion( 
         title: String!, 
         question: String!, 
-        user_id: ID!, 
+        user_id: ID, 
         tags: [String],
         answers_ids: [ID]): Question
 
@@ -73,7 +73,7 @@ const typeDefs = [`
       createAnswer( 
         question_id: ID!,
         answer: String!, 
-        user_id: ID!): Answer
+        user_id: ID): Answer
 
       updateAnswer(
         question_id: ID!, 
@@ -89,5 +89,6 @@ const typeDefs = [`
       query: Query
       mutation: Mutation
     }
-  `];
+  `,
+];
 export default typeDefs;

--- a/frontend/src/components/Router.js
+++ b/frontend/src/components/Router.js
@@ -5,14 +5,14 @@ import GiveAnswer from '../screens/GiveAnswer';
 import NewQuestion from '../screens/NewQuestion';
 import NotFound from '../screens/NotFound';
 const Router = () => (
-	<BrowserRouter>
-		<Switch>
-			<Route path="/" exact component={App} />
-			<Route path="/giveanswer" exact component={GiveAnswer} />
-			<Route path="/newquestion" exact component={NewQuestion} />
-			<Route component={NotFound} />
-		</Switch>
-	</BrowserRouter>
+  <BrowserRouter>
+    <Switch>
+      <Route path="/" exact component={App} />
+      <Route path="/giveanswer/:questionId" exact component={GiveAnswer} />
+      <Route path="/newquestion" exact component={NewQuestion} />
+      <Route component={NotFound} />
+    </Switch>
+  </BrowserRouter>
 );
 
 export default Router;

--- a/frontend/src/screens/GiveAnswer.js
+++ b/frontend/src/screens/GiveAnswer.js
@@ -44,7 +44,7 @@ class GiveAnswer extends Component {
   renderQuestion() {
     if (!this.props.data.loading) {
       const question = this.props.data.questions.filter(
-        question => question._id === 'cdea5b19-a640-4db6-8456-955bad32c755'
+        question => question._id === 'a8259359-b78d-48b0-989e-d523aa749776'
       );
       const questionTitle = question[0].title;
       const questionCreateAt = question[0].createAt;

--- a/frontend/src/screens/NewQuestion.js
+++ b/frontend/src/screens/NewQuestion.js
@@ -1,51 +1,47 @@
 import React, { Component } from 'react';
+import { graphql } from 'react-apollo';
+import gql from 'graphql-tag';
+import { Link } from 'react-router-dom';
 import { user } from '../resources/images';
 import { blue, green } from '../resources/colors';
-import { Header, ListItem, Footer } from '../components';
+import { Header, Footer } from '../components';
 
-export default class NewQuestion extends Component {
+class NewQuestion extends Component {
   state = {
-    questions: [],
-    newTitle: [],
+    title: '',
+    question: 'question from state',
   };
 
-  askQuestion = e => {
+  createQuestion = e => {
     e.preventDefault();
-    this.setState({
-      questions: [...this.state.questions, this.state.newTitle],
-      newTitle: [],
-    });
+    this.props
+      .mutate({
+        variables: {
+          title: this.state.title,
+          question: this.state.question,
+        },
+      })
+      .then(data =>
+        this.props.history.push(`/giveanswer/${data.data.createQuestion._id}`)
+      )
+      .catch(err => console.log(err));
   };
 
   handleChange = e => {
-    this.setState({ newTitle: e.target.value });
+    this.setState({ title: e.target.value });
   };
 
   render() {
     return (
       <div style={container}>
         <Header />
-
-        <div style={gridView}>
-          <div>
-            {this.state.questions.map(question => (
-              <ListItem
-                title={question}
-                user={'User001'}
-                date={'Just now'}
-                likes={'0'}
-              />
-            ))}
-          </div>
-        </div>
-
         <div style={gridView}>
           <div style={formView}>
-            <form onSubmit={this.askQuestion}>
+            <form onSubmit={this.createQuestion}>
               <textarea
                 style={newQuestionForm}
-                placeholder="Add new question"
-                value={this.state.newTitle}
+                placeholder="Add question title"
+                value={this.state.title}
                 onChange={this.handleChange}
               />
               <br />
@@ -61,6 +57,18 @@ export default class NewQuestion extends Component {
     );
   }
 }
+
+const CREATE_QUESTION = gql`
+  mutation createQuestion($title: String!, $question: String!) {
+    createQuestion(title: $title, question: $question) {
+      _id
+      title
+      question
+    }
+  }
+`;
+
+export default graphql(CREATE_QUESTION)(NewQuestion);
 
 const container = {};
 const formView = {


### PR DESCRIPTION
**`createAnswer` mutation**
I implemented the `createAnswer` mutation in the `NewQuestion.js` screen.

**Routing:**
`onSubmit` from `NewQuestion.js` now redirects to `/giveanswer/:questionId`. `GiveAnswer.js` screen might behave weird because the `question_id` fetching is not implemented yet on `GiveAnswer.js`. In other words, `GiveAnswer.js` screen still doesn't now from what question the redirection came from (thoughts on how to fetch the `question_id` on redirect from `NewQuestion.js` to `GiveAnswer.js`?).

**Temp changes:**
I temporarily removed from `typeDefs.js` the requirement for `user_id` both in `createAnswer` and `createQuestion` because I was having trouble hard coding the id. I tried to research a bit on "ID Types" but it didn't suffice. Tips are welcome.

P.S. ignore the last commit. That's a local merge branch commit because I work locally in different branches and I'm still figuring it out.