### PR TITLE
Solve issue #67 and fix typos

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -2305,8 +2305,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2327,14 +2326,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2349,20 +2346,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2479,8 +2473,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2492,7 +2485,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2507,7 +2499,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2515,14 +2506,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2541,7 +2530,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2622,8 +2610,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2635,7 +2622,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2721,8 +2707,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2758,7 +2743,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2778,7 +2762,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2822,14 +2805,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -2880,7 +2861,6 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-glob": "^2.0.0"
       }
@@ -3319,8 +3299,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -3342,7 +3321,6 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-extglob": "^1.0.0"
       }
@@ -4299,7 +4277,6 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
-      "optional": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
       }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3197,8 +3197,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -3216,13 +3215,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3235,18 +3232,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -3349,8 +3343,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -3360,7 +3353,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -3373,20 +3365,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3403,7 +3392,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -3476,8 +3464,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3487,7 +3474,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3563,8 +3549,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3594,7 +3579,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -3612,7 +3596,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3651,13 +3634,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -6783,8 +6764,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6802,13 +6782,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6821,18 +6799,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6935,8 +6910,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6946,7 +6920,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6959,20 +6932,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6989,7 +6959,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7062,8 +7031,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7073,7 +7041,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7149,8 +7116,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7180,7 +7146,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7198,7 +7163,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7237,13 +7201,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -16760,8 +16722,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -16779,13 +16740,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -16798,18 +16757,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -16912,8 +16868,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -16923,7 +16878,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -16936,20 +16890,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.2.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.1",
                 "yallist": "^3.0.0"
@@ -16966,7 +16917,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -17039,8 +16989,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -17050,7 +16999,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -17126,8 +17074,7 @@
             },
             "safe-buffer": {
               "version": "5.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -17157,7 +17104,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -17175,7 +17121,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -17214,13 +17159,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         }

--- a/frontend/src/components/ListItem.js
+++ b/frontend/src/components/ListItem.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
 import { green, purple, grey } from '../resources/colors';
 import { user } from '../resources/images';
 import styled from 'styled-components';
@@ -12,8 +13,9 @@ export default class ListItem extends Component {
   render() {
     return (
       <ListContainer>
-        <Title>{this.props.title}</Title>
-
+				<StyledLink key={this.props.questionId} to={`/giveanswer/${this.props.questionId}`}>
+        	<Title>{this.props.title}</Title>
+				</StyledLink>
         <Item>
           <Avatar src={user} alt={user} />
 
@@ -118,4 +120,8 @@ const HeartFill = styled.div`
   &:hover {
     color: ${purple}
   }
+`
+
+const StyledLink = styled(Link)`
+  text-decoration: none;
 `

--- a/frontend/src/components/ListItem.js
+++ b/frontend/src/components/ListItem.js
@@ -22,7 +22,6 @@ export default class ListItem extends Component {
           <div style={{ marginLeft: 15, float: 'left', width:'85%' }}>
             <Username>{this.props.user}</Username>
             <Date>{'published on ' + this.props.date.split('').slice(0, 10).join('')}</Date>
-						{console.log(this.props.date.split('').slice(0, 10).join(''))}
           </div>
 
           <div style={{ marginLeft: '15px', float: 'right', width:'15%' }}>

--- a/frontend/src/components/ListItem.js
+++ b/frontend/src/components/ListItem.js
@@ -21,7 +21,8 @@ export default class ListItem extends Component {
 
           <div style={{ marginLeft: 15, float: 'left', width:'85%' }}>
             <Username>{this.props.user}</Username>
-            <Date>{'published on ' + this.props.date}</Date>
+            <Date>{'published on ' + this.props.date.split('').slice(0, 10).join('')}</Date>
+						{console.log(this.props.date.split('').slice(0, 10).join(''))}
           </div>
 
           <div style={{ marginLeft: '15px', float: 'right', width:'15%' }}>

--- a/frontend/src/components/ListItem.js
+++ b/frontend/src/components/ListItem.js
@@ -3,30 +3,39 @@ import { Link } from 'react-router-dom';
 import { green, purple, grey } from '../resources/colors';
 import { user } from '../resources/images';
 import styled from 'styled-components';
-import { library } from '@fortawesome/fontawesome-svg-core'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faHeart } from '@fortawesome/free-solid-svg-icons'
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faHeart } from '@fortawesome/free-solid-svg-icons';
 
-library.add(faHeart)
+library.add(faHeart);
 
 export default class ListItem extends Component {
   render() {
     return (
       <ListContainer>
-				<StyledLink key={this.props.questionId} to={`/giveanswer/${this.props.questionId}`}>
-        	<Title>{this.props.title}</Title>
-				</StyledLink>
+        <StyledLink key={this.props.questionId} to={`/giveanswer/${this.props.questionId}`}>
+          <Title>{this.props.title}</Title>
+        </StyledLink>
         <Item>
           <Avatar src={user} alt={user} />
 
-          <div style={{ marginLeft: 15, float: 'left', width:'85%' }}>
+          <div style={{ marginLeft: 15, float: 'left', width: '85%' }}>
             <Username>{this.props.user}</Username>
-            <Date>{'published on ' + this.props.date.split('').slice(0, 10).join('')}</Date>
+            <Date>
+              {'published on ' +
+                this.props.date
+                  .split('')
+                  .slice(0, 10)
+                  .join('')}
+            </Date>
           </div>
 
-          <div style={{ marginLeft: '15px', float: 'right', width:'15%' }}>
+          <div style={{ marginLeft: '15px', float: 'right', width: '15%' }}>
             <HeartFill>
-              <FontAwesomeIcon icon='heart' style={{fontSize:'25px', stroke:`${purple}`, strokeWidth:10}}/>
+              <FontAwesomeIcon
+                icon="heart"
+                style={{ fontSize: '25px', stroke: `${purple}`, strokeWidth: 10 }}
+              />
             </HeartFill>
             <Likes>{this.props.likes + ' likes '}</Likes>
           </div>
@@ -49,7 +58,7 @@ const ListContainer = styled.div`
   box-shadow: 0px 0px 8px 4px gainsboro;
   padding: 0 15px 15px 20px;
   margin-bottom: 20px;
-`
+`;
 
 const Item = styled.div`
   display: flex;
@@ -58,7 +67,7 @@ const Item = styled.div`
   max-width: 100%;
   margin-top: -15px;
   align-items: center;
-`
+`;
 
 /*const Like = styled.img`
   height: 20px;
@@ -80,7 +89,7 @@ const Title = styled.p`
   /*color: #7f7f7f;*/
   color: black;
   justify-content: flex-start;
-`
+`;
 
 const Date = styled.p`
   font-size: 12px;
@@ -88,7 +97,7 @@ const Date = styled.p`
   margin-top: 0px;
   padding-right: 5px;
   text-align: left;
-`
+`;
 
 const Username = styled.p`
   font-size: 14px;
@@ -101,27 +110,27 @@ const Username = styled.p`
   border-width: 6px;
   resize-mode: cover;
   background-color: ${green};
-`
+`;
 
 const Avatar = styled.img`
-    height: 35px;
-    width: 35px;
-    border-radius: 40px;
-    border: 30px solid;
-    border-color: ${green};
-    border-width: 6px;
-    resize-mode: cover;
-    background-color: ${green};
+  height: 35px;
+  width: 35px;
+  border-radius: 40px;
+  border: 30px solid;
+  border-color: ${green};
+  border-width: 6px;
+  resize-mode: cover;
+  background-color: ${green};
 `;
 
 const HeartFill = styled.div`
   color: white;
 
   &:hover {
-    color: ${purple}
+    color: ${purple};
   }
-`
+`;
 
 const StyledLink = styled(Link)`
   text-decoration: none;
-`
+`;

--- a/frontend/src/screens/GiveAnswer.js
+++ b/frontend/src/screens/GiveAnswer.js
@@ -74,7 +74,7 @@ class GiveAnswer extends Component {
         return (
           <Answer
             key={_id}
-            title={answer}
+            answer={answer}
             user={'TheAnswerGiver'}
             date={'10000 B.C.'}
             likes={'0'}

--- a/frontend/src/screens/GiveAnswer.js
+++ b/frontend/src/screens/GiveAnswer.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { graphql, compose } from 'react-apollo';
 import gql from 'graphql-tag';
 import { green } from '../resources/colors';
-import { CompleteItem, Answer, SideList, Header, Footer } from '../components';
+import { CompleteItem, Answer, Header, Footer } from '../components';
 import { library } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSpinner } from '@fortawesome/free-solid-svg-icons';

--- a/frontend/src/screens/Home.js
+++ b/frontend/src/screens/Home.js
@@ -2,31 +2,37 @@ import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import { ListItem, SideList, Header, Footer } from '../components';
 import styled from 'styled-components';
-import { green } from "../resources/colors";
+import { green } from '../resources/colors';
 import { graphql } from 'react-apollo';
 import gql from 'graphql-tag';
-import { library } from '@fortawesome/fontawesome-svg-core'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faSpinner } from '@fortawesome/free-solid-svg-icons'
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faSpinner } from '@fortawesome/free-solid-svg-icons';
 
-library.add(faSpinner)
+library.add(faSpinner);
 
 class Home extends Component {
   renderQuestions() {
     if (this.props.data.loading) {
-      return <FontAwesomeIcon icon='spinner' spin style={{fontSize:'50px', alignItems:'center', margin:'0 auto', color:`${green}`}} />;
+      return (
+        <FontAwesomeIcon
+          icon="spinner"
+          spin
+          style={{ fontSize: '50px', alignItems: 'center', margin: '0 auto', color: `${green}` }}
+        />
+      );
     } else {
       return this.props.data.questions.map(question => {
-				const questionId = question._id;
+        const questionId = question._id;
         return (
-					<ListItem
-						key={questionId}
-						questionId={questionId}
-						title={question.title}
-						user={'Hanen Wahabi'}
-						date={question.createAt}
-						likes={'4'}
-					/>
+          <ListItem
+            key={questionId}
+            questionId={questionId}
+            title={question.title}
+            user={'Hanen Wahabi'}
+            date={question.createAt}
+            likes={'4'}
+          />
         );
       });
     }
@@ -67,17 +73,17 @@ const ListView = styled.div`
   flex: 3;
   flex-direction: column;
   max-width: 50%;
-`
+`;
 const GridView = styled.div`
   display: flex;
   flex: 1;
   flex-direction: row;
   margin-top: 40;
-`
+`;
 
 const StyledLink = styled(Link)`
   text-decoration: none;
-`
+`;
 
 /* const form = styled.`
 	display: flex;

--- a/frontend/src/screens/Home.js
+++ b/frontend/src/screens/Home.js
@@ -17,16 +17,16 @@ class Home extends Component {
       return <FontAwesomeIcon icon='spinner' spin style={{fontSize:'50px', alignItems:'center', margin:'0 auto', color:`${green}`}} />;
     } else {
       return this.props.data.questions.map(question => {
+				const questionId = question._id;
         return (
-          <StyledLink key={question._id} to={`/giveanswer/${question._id}`}>
-            <ListItem
-              key={question._id}
-              title={question.title}
-              user={'Hanen Wahabi'}
-              date={question.createAt}
-              likes={'4'}
-            />
-          </StyledLink>
+					<ListItem
+						key={questionId}
+						questionId={questionId}
+						title={question.title}
+						user={'Hanen Wahabi'}
+						date={question.createAt}
+						likes={'4'}
+					/>
         );
       });
     }


### PR DESCRIPTION
Issue #67 suggested reformatting the date of `ListItem` components in `Home.js`; this was fixed (see issue #67 for details on the fix). The `ListItem` components on `Home.js` would redirect to `GiveAnswer.js` regardless of where they were clicked; this was also fixed and now only the question's title redirects.

Additionaly typos were fixed such as changing the `title` props from `Answer.js` to `answer`.