### PR TITLE
Add "All Questions" option

### DIFF
--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -95,7 +95,7 @@ class Header extends Component {
         <StyledLink exact="true" to={'/'}>
           <Logo />
         </StyledLink>
-        <SearchBar onChangeText={this.props.onChangeText} onSearch={this.props.onSearch} />
+        <SearchBar onChangeText={this.props.onChangeText} onSearch={this.props.onSearch} value={this.props.searchText} />
         {rememToken ? (
           <StyledLink to={'/newquestion'}>
             <Section title="Ask" />

--- a/frontend/src/components/SideList.js
+++ b/frontend/src/components/SideList.js
@@ -13,7 +13,7 @@ export default class SideList extends Component {
   };
   render() {
     const { selected } = this.state;
-    const { selectMyQ, selectSolved, selectUnsolved } = this.props;
+    const { selectMyQ, selectSolved, selectUnsolved, selectAll } = this.props;
     return (
       <SideListDiv>
         <SideItem
@@ -75,6 +75,37 @@ export default class SideList extends Component {
             }}
           >
             {'Solved'}
+          </p>
+        </SideItem>
+        
+				<SideItem
+          onClick={() => {
+            selectAll();
+            this.setState({ selected: '' });
+          }}
+          style={{
+            backgroundColor: selected === '' ? 'rgba(47, 224, 144, .2)' : 'transparent',
+            width: '80%',
+            border: '1px solid transparent',
+            borderRadius: '15px',
+            padding: '0 10px',
+            alignItems: 'center',
+          }}
+        >
+          <FontAwesomeIcon
+            icon="check-circle"
+            style={{ fontSize: '25px', color: selected === '' ? green : 'black' }}
+          />
+          <p
+            style={{
+              fontSize: 14,
+              borderRadius: 8,
+              paddingLeft: 5,
+              paddingRight: 5,
+              color: selected === '' ? green : grey,
+            }}
+          >
+            {'All'}
           </p>
         </SideItem>
 

--- a/frontend/src/screens/Home.js
+++ b/frontend/src/screens/Home.js
@@ -127,6 +127,11 @@ class Home extends Component {
                 this.onSearch()
               )
             }
+            selectAll={() =>
+              this.setState({ solved: false, unsolved: false, my_questions: false }, () =>
+                this.onSearch()
+              )
+            }
           />
           <ListView>
             <h2 style={{ textAlign: 'left' }}>Top Questions</h2>

--- a/frontend/src/screens/Home.js
+++ b/frontend/src/screens/Home.js
@@ -128,7 +128,7 @@ class Home extends Component {
               )
             }
             selectAll={() =>
-              this.setState({ solved: false, unsolved: false, my_questions: false }, () =>
+              this.setState({ searchText: '', solved: false, unsolved: false, my_questions: false }, () =>
                 this.onSearch()
               )
             }


### PR DESCRIPTION
Add "All" side list item that takes care of issue #95.

_However_, it comes with some search quirks or issues that I tried to tackle but couldn't solve:

**1:**
- **TL;DR:** clicking the "All" side list item resets `state.searchText` to an empty string but the search query is still displayed on the search bar.
- **Detailed explanation**: when the user clicks the "All" side list item, the `state.searchText` has to be reset to an empty string to display **all** questions. The problem here is that the value of the search bar **does not** get reset. In other words, if the user searches for "React", results are displayed. If the user then clicks "All", all questions will be displayed but the search text "React" is still displayed in the search bar. This creates an inconsistency between what's displayed and `state.searchText`. **Fix:** reset the search bar value. **Issue:** how?

**2:**
- if the user searches for the keyword "React", results are displayed. If the user then clicks "Solved" or "Unsolved", this will only display the solved or unsolved questions found as a result of the "React" search query. Do we want to display **all** solved and unsolved questions **or** only the query's solved and unsolved ones? If the former is preferred, this would be an easy fix but would also suffer from the above mentioned issue 1.

These are not crucial but can create some confusion in the user's experience. What do you think?